### PR TITLE
fix: translation.test.tsのインポートパスを修正

### DIFF
--- a/workers/src/__tests__/routes/translation.test.ts
+++ b/workers/src/__tests__/routes/translation.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import app from '../../src/index';
+import app from '../../index';
 
 // fetchのモック
 const mockFetch = vi.fn();


### PR DESCRIPTION
- `../../src/index` から `../../index` に変更
- テストファイルが既にsrcディレクトリ内にあるため、相対パスが不正確だった

🤖 Generated with [Claude Code](https://claude.ai/code)