### PR TITLE
fix: フロントエンドテストファイルのインポートパスを修正

### DIFF
--- a/frontend/src/components/steps/__tests__/CategoryStep.category-change.test.tsx
+++ b/frontend/src/components/steps/__tests__/CategoryStep.category-change.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { CategoryStep } from './CategoryStep';
+import { CategoryStep } from '../CategoryStep';
 import { usePromptStore } from '@/stores/promptStore';
 
 // Mock the store

--- a/frontend/src/components/steps/__tests__/CategoryStep.test.tsx
+++ b/frontend/src/components/steps/__tests__/CategoryStep.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { CategoryStep } from './CategoryStep';
+import { CategoryStep } from '../CategoryStep';
 import { usePromptStore } from '@/stores/promptStore';
 
 // Mock the store

--- a/frontend/src/components/steps/__tests__/StyleStep.test.tsx
+++ b/frontend/src/components/steps/__tests__/StyleStep.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { StyleStep } from './StyleStep';
+import { StyleStep } from '../StyleStep';
 import { usePromptStore } from '@/stores/promptStore';
 
 // モック

--- a/frontend/src/services/__tests__/commercialImageGeneration.test.ts
+++ b/frontend/src/services/__tests__/commercialImageGeneration.test.ts
@@ -4,8 +4,8 @@ import {
   checkPromptLength,
   saveLastUsedService,
   getLastUsedService,
-} from './commercialImageGeneration';
-import { ImageGenerationService } from '../config/commercialImageServices';
+} from '../commercialImageGeneration';
+import { ImageGenerationService } from '../../config/commercialImageServices';
 
 describe('commercialImageGeneration', () => {
   beforeEach(() => {


### PR DESCRIPTION
- __tests__ディレクトリ内のテストファイルから親ディレクトリのコンポーネントを正しく参照するよう修正
- commercialImageGeneration.test.ts: ./から../に変更
- CategoryStep関連テスト: ./CategoryStepから../CategoryStepに変更
- StyleStep.test.tsx: ./StyleStepから../StyleStepに変更

🤖 Generated with [Claude Code](https://claude.ai/code)