### PR TITLE
fix: ImageGenerationSection.test.tsxのインポートパスを修正

### DIFF
--- a/frontend/src/components/__tests__/ImageGenerationSection.test.tsx
+++ b/frontend/src/components/__tests__/ImageGenerationSection.test.tsx
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { ImageGenerationSection } from './ImageGenerationSection';
-import * as imageGeneration from '../services/commercialImageGeneration';
+import { ImageGenerationSection } from '../ImageGenerationSection';
+import * as imageGeneration from '../../services/commercialImageGeneration';
 
 // モックの設定
 vi.mock('@/stores/languageStore', () => ({
   useLanguageStore: () => ({ language: 'ja' }),
 }));
 
-vi.mock('../services/commercialImageGeneration', () => ({
+vi.mock('../../services/commercialImageGeneration', () => ({
   copyPromptToClipboard: vi.fn(),
   openImageService: vi.fn(),
   saveLastUsedService: vi.fn(),


### PR DESCRIPTION
- __tests__ディレクトリからの相対パスを修正
- ./ImageGenerationSection → ../ImageGenerationSection
- ../services/commercialImageGeneration → ../../services/commercialImageGeneration

🤖 Generated with [Claude Code](https://claude.ai/code)