### PR TITLE
test: デフォルトモデル変更に伴うテストケースの更新

### DIFF
--- a/workers/src/__tests__/routes/image.test.ts
+++ b/workers/src/__tests__/routes/image.test.ts
@@ -8,9 +8,9 @@ vi.mock('../../services/imageProviders/replicate', () => ({
   generateWithReplicate: vi.fn(),
   getAvailableReplicateModels: vi.fn(() => [
     {
-      id: 'flux-fill',
-      name: 'FLUX Fill',
-      description: 'Professional inpainting and outpainting model',
+      id: 'sdxl-img2img',
+      name: 'Stable Diffusion XL',
+      description: 'SDXL image-to-image model',
       version: 'test-version',
     },
   ]),
@@ -286,7 +286,7 @@ describe('Image API Routes', () => {
           outputFormat: 'jpeg',
         },
         'test-api-key',
-        'flux-fill',
+        'sdxl-img2img',
         mockEnv
       );
     });


### PR DESCRIPTION
## Summary
デプロイ時のテストエラーを修正しました。

## 問題
デフォルトモデルを`flux-fill`から`sdxl-img2img`に変更したが、テストケースが古いモデルを期待していたため、CI/CDでテストが失敗していました。

## 修正内容
- `workers/src/__tests__/routes/image.test.ts`のテストケースを更新
- 期待値を`sdxl-img2img`に変更
- モックのモデル情報も更新

## 結果
- テストが正常に通るようになりました
- GitHub ActionsのCIが成功します

## Test plan
- [x] `npm test`がローカルで成功することを確認
- [ ] GitHub ActionsのCIが成功することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)